### PR TITLE
Update Swagger UI setup to use CDN assets directly

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -145,13 +145,16 @@ app.get('/healthz', async (req, res) => {
     return next();
 }
 
-// Handle preflight OPTIONS requests for all API routes
-app.options('/api/v1/*', (req, res) => {
-    res.header('Access-Control-Allow-Origin', req.headers.origin || '*');
-    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS');
-    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization, Cache-Control, Pragma');
-    res.header('Access-Control-Allow-Credentials', 'true');
-    res.sendStatus(204);
+// Handle preflight OPTIONS requests for all API routes using middleware
+app.use('/api/v1', (req, res, next) => {
+    if (req.method === 'OPTIONS') {
+        res.header('Access-Control-Allow-Origin', req.headers.origin || '*');
+        res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS');
+        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization, Cache-Control, Pragma');
+        res.header('Access-Control-Allow-Credentials', 'true');
+        return res.sendStatus(204);
+    }
+    next();
 });
 
 app.use('/api/v1', ensureDB, routes);

--- a/src/app.js
+++ b/src/app.js
@@ -23,9 +23,30 @@ app.use(requestLoggingMiddleware);
 
 app.use(express.json());
 
-app.use(cors({
-    origin: process.env.ORIGIN,
-}));
+// Configure CORS to allow Swagger UI and API testing
+const corsOptions = {
+    origin: process.env.NODE_ENV === 'production'
+        ? [
+            'https://octacore.githubsrmist.in',
+            'https://gcsrm-server.vercel.app',
+            'https://gcsrm-server-*.vercel.app' // Allow preview deployments
+        ]
+        : true, // Allow all origins in development
+    credentials: true,
+    optionsSuccessStatus: 200,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+    allowedHeaders: [
+        'Origin',
+        'X-Requested-With',
+        'Content-Type',
+        'Accept',
+        'Authorization',
+        'Cache-Control',
+        'Pragma'
+    ]
+};
+
+app.use(cors(corsOptions));
 
 // Morgan logging (keep for file logs if needed)
 if (process.env.NODE_ENV === 'production') {
@@ -123,6 +144,15 @@ app.get('/healthz', async (req, res) => {
     }
     return next();
 }
+
+// Handle preflight OPTIONS requests for all API routes
+app.options('/api/v1/*', (req, res) => {
+    res.header('Access-Control-Allow-Origin', req.headers.origin || '*');
+    res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS');
+    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization, Cache-Control, Pragma');
+    res.header('Access-Control-Allow-Credentials', 'true');
+    res.sendStatus(204);
+});
 
 app.use('/api/v1', ensureDB, routes);
 

--- a/src/utils/swagger.js
+++ b/src/utils/swagger.js
@@ -1,6 +1,5 @@
 const swaggerJsDoc = require("swagger-jsdoc");
 const swaggerUi = require("swagger-ui-express");
-const path = require("path");
 
 const options = {
     definition: {
@@ -182,136 +181,14 @@ const options = {
             }
         }
     },
-    apis: [path.join(__dirname, "../routes/*.js")]
+    apis: ["./src/routes/*.js"]
 };
 
 const swaggerSpec = swaggerJsDoc(options);
 
 const swaggerDocs = (app) => {
-    try {
-        // Configuration for serverless environments (like Vercel)
-        const swaggerOptions = {
-            explorer: true,
-            customCss: '.swagger-ui .topbar { display: none }',
-            customSiteTitle: "GCSRM API Documentation",
-            // Use CDN for assets to avoid static file serving issues on Vercel
-            swaggerOptions: {
-                url: null, // We'll provide the spec directly
-            },
-            // Configure to use CDN resources
-            customfavIcon: "https://cdn.jsdelivr.net/npm/swagger-ui-dist/favicon-32x32.png",
-            customCssUrl: [
-                "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css"
-            ],
-            customJs: [
-                "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js",
-                "https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-standalone-preset.js"
-            ]
-        };
-
-        // Alternative setup for serverless environments
-        if (process.env.NODE_ENV === 'production') {
-            // For production, we'll serve a custom HTML page with CDN resources
-            app.get('/api-docs', (req, res) => {
-                const html = `
-                <!DOCTYPE html>
-                <html lang="en">
-                <head>
-                    <meta charset="UTF-8">
-                    <title>GCSRM API Documentation</title>
-                    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
-                    <style>
-                        html {
-                            box-sizing: border-box;
-                            overflow: -moz-scrollbars-vertical;
-                            overflow-y: scroll;
-                        }
-                        *, *:before, *:after {
-                            box-sizing: inherit;
-                        }
-                        body {
-                            margin:0;
-                            background: #fafafa;
-                        }
-                        .swagger-ui .topbar { display: none }
-                    </style>
-                </head>
-                <body>
-                    <div id="swagger-ui"></div>
-                    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
-                    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
-                    <script>
-                        window.onload = function() {
-                            const ui = SwaggerUIBundle({
-                                url: '/api-docs/swagger.json',
-                                dom_id: '#swagger-ui',
-                                deepLinking: true,
-                                presets: [
-                                    SwaggerUIBundle.presets.apis,
-                                    SwaggerUIStandalonePreset
-                                ],
-                                plugins: [
-                                    SwaggerUIBundle.plugins.DownloadUrl
-                                ],
-                                layout: "StandaloneLayout"
-                            });
-                        };
-                    </script>
-                </body>
-                </html>`;
-                res.send(html);
-            });
-
-            // Serve the swagger spec as JSON
-            app.get('/api-docs/swagger.json', (req, res) => {
-                res.setHeader('Content-Type', 'application/json');
-                res.send(swaggerSpec);
-            });
-        } else {
-            // For development, use the standard setup
-            app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec, swaggerOptions));
-        }
-
-        // Log the swagger spec for debugging
-        console.log("Swagger spec generated successfully");
-        console.log(`Found ${Object.keys(swaggerSpec.paths || {}).length} API paths`);
-
-        // Debug: Log available paths
-        if (swaggerSpec.paths) {
-            console.log("Available API endpoints:");
-            Object.keys(swaggerSpec.paths).forEach(path => {
-                const methods = Object.keys(swaggerSpec.paths[path]);
-                console.log(`  ${path}: ${methods.join(', ')}`);
-            });
-        }
-
-        const port = process.env.PORT || 3000;
-        const host = process.env.NODE_ENV === 'production'
-            ? 'https://octacore.githubsrmist.in'
-            : `http://localhost:${port}`;
-
-        console.log(`Swagger docs available at ${host}/api-docs`);
-        console.log(`Swagger JSON spec available at ${host}/api-docs/swagger.json`);
-        console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-    } catch (error) {
-        console.error("Error setting up Swagger documentation:", error);
-        console.error("Stack trace:", error.stack);
-
-        // Fallback: provide a simple error page
-        app.get('/api-docs', (req, res) => {
-            res.status(500).send(`
-                <html>
-                <head><title>API Documentation Error</title></head>
-                <body>
-                    <h1>API Documentation Unavailable</h1>
-                    <p>There was an error setting up the Swagger documentation.</p>
-                    <p>Error: ${error.message}</p>
-                    <p>Please check the server logs for more details.</p>
-                </body>
-                </html>
-            `);
-        });
-    }
+    app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+    console.log("Swagger docs available at http://localhost:3000/api-docs");
 };
 
 module.exports = swaggerDocs;

--- a/src/utils/swagger.js
+++ b/src/utils/swagger.js
@@ -7,7 +7,7 @@ const options = {
         info: {
             title: "GCSRM API",
             version: "1.0.0",
-            description: "API documentation for GitHub Club SRM Server - handles team members and sponsors management",
+            description: "API documentation for GitHub Club SRM Server - handles team members and sponsors management.\n\n**Testing the API:** Use the 'Current server' option in the servers dropdown above to avoid CORS issues when testing endpoints. Cross-origin requests to external servers may be blocked by browser security policies.",
             contact: {
                 name: "GitHub Club SRM",
                 email: "contact@githubsrm.tech"
@@ -19,12 +19,16 @@ const options = {
         },
         servers: [
             {
+                url: "/api/v1",
+                description: "Current server (same origin - recommended for testing)"
+            },
+            {
                 url: "http://localhost:3000/api/v1",
                 description: "Local development server"
             },
             {
                 url: "https://octacore.githubsrmist.in/api/v1",
-                description: "Production server"
+                description: "Production server (may have CORS restrictions)"
             }
         ],
         components: {
@@ -187,8 +191,38 @@ const options = {
 const swaggerSpec = swaggerJsDoc(options);
 
 const swaggerDocs = (app) => {
-    app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-    console.log("Swagger docs available at http://localhost:3000/api-docs");
+    // Enhanced Swagger UI options for better CORS handling
+    const swaggerUiOptions = {
+        customCss: '.swagger-ui .topbar { display: none }',
+        customSiteTitle: "GCSRM API Documentation",
+        swaggerOptions: {
+            // Use the current server as default to avoid CORS issues
+            servers: [
+                {
+                    url: "/api/v1",
+                    description: "Current server (recommended)"
+                }
+            ],
+            // Enable request interception to handle CORS
+            requestInterceptor: function (request) {
+                // Set credentials for same-origin requests
+                if (request.url.startsWith('/') || request.url.includes(window.location.origin)) {
+                    request.credentials = 'same-origin';
+                }
+                return request;
+            },
+            responseInterceptor: function (response) {
+                // Handle CORS errors gracefully
+                if (response.status === 0) {
+                    response.text = 'CORS Error: Cross-origin request blocked. Use the "Current server" option above to test the API from the same origin.';
+                }
+                return response;
+            }
+        }
+    };
+
+    app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec, swaggerUiOptions));
+    console.log("Swagger docs available at /api-docs");
 };
 
 module.exports = swaggerDocs;

--- a/vercel.json
+++ b/vercel.json
@@ -1,28 +1,22 @@
 {
     "version": 2,
-    "builds": [
-        {
-            "src": "index.js",
-            "use": "@vercel/node"
-        }
-    ],
-    "routes": [
-        {
-            "src": "/api/swagger-ui.css",
-            "dest": "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui.min.css"
-        },
-        {
-            "src": "/api/swagger-ui-bundle.js",
-            "dest": "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui-bundle.min.js"
-        },
-        {
-            "src": "/api/swagger-ui-standalone-preset.js",
-            "dest": "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui-standalone-preset.min.js"
-        }
-    ],
     "functions": {
         "index.js": {
             "includeFiles": "src/**"
         }
-    }
+    },
+    "rewrites": [
+        {
+            "source": "/api-docs/swagger-ui.css",
+            "destination": "https://unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css"
+        },
+        {
+            "source": "/api-docs/swagger-ui-bundle.js",
+            "destination": "https://unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-bundle.js"
+        },
+        {
+            "source": "/api-docs/swagger-ui-standalone-preset.js",
+            "destination": "https://unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-standalone-preset.js"
+        }
+    ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -8,17 +8,17 @@
     ],
     "routes": [
         {
-            "src": "/api-docs/(.*)",
-            "dest": "/index.js"
+            "src": "/api/swagger-ui.css",
+            "dest": "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui.min.css"
         },
         {
-            "src": "/api/(.*)",
-            "dest": "/index.js"
+            "src": "/api/swagger-ui-bundle.js",
+            "dest": "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui-bundle.min.js"
         },
         {
-            "src": "/(.*)",
-            "dest": "/index.js"
-        }
+            "src": "/api/swagger-ui-standalone-preset.js",
+            "dest": "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui-standalone-preset.min.js"
+        },
     ],
     "functions": {
         "index.js": {

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,25 @@
             "includeFiles": "src/**"
         }
     },
+    "headers": [
+        {
+            "source": "/api/(.*)",
+            "headers": [
+                {
+                    "key": "Access-Control-Allow-Origin",
+                    "value": "*"
+                },
+                {
+                    "key": "Access-Control-Allow-Methods",
+                    "value": "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+                },
+                {
+                    "key": "Access-Control-Allow-Headers",
+                    "value": "Origin, X-Requested-With, Content-Type, Accept, Authorization, Cache-Control, Pragma"
+                }
+            ]
+        }
+    ],
     "rewrites": [
         {
             "source": "/api-docs/swagger-ui.css",

--- a/vercel.json
+++ b/vercel.json
@@ -18,7 +18,7 @@
         {
             "src": "/api/swagger-ui-standalone-preset.js",
             "dest": "https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/4.15.5/swagger-ui-standalone-preset.min.js"
-        },
+        }
     ],
     "functions": {
         "index.js": {


### PR DESCRIPTION
Serve Swagger UI assets from a CDN and simplify the documentation setup by removing unused code. This change enhances performance and reduces server load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API docs consistently available at /api-docs in all environments.
  - Added a "current-testing" server entry and guidance for testing the API.

- **Documentation**
  - Consolidated Swagger UI into a single, consistent entry point with updated API description and CORS notes.
  - Swagger UI assets served via CDN for faster loading.

- **Bug Fixes**
  - More robust CORS handling, including explicit preflight responses and refined origin/headers/methods rules.

- **Refactor**
  - Removed environment-specific branching for docs and simplified deployment routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->